### PR TITLE
Zombie proc fix

### DIFF
--- a/nbclient/exceptions.py
+++ b/nbclient/exceptions.py
@@ -40,9 +40,11 @@ class CellExecutionError(Exception):
     failures gracefully.
     """
 
-    def __init__(self, traceback):
+    def __init__(self, traceback, ename, evalue):
         super(CellExecutionError, self).__init__(traceback)
         self.traceback = traceback
+        self.ename = ename
+        self.evalue = evalue
 
     def __str__(self):
         s = self.__unicode__()
@@ -65,8 +67,10 @@ class CellExecutionError(Exception):
                 traceback=tb,
                 ename=msg.get('ename', '<Error>'),
                 evalue=msg.get('evalue', ''),
-            )
-        )
+            ),
+            ename=msg.get('ename', '<Error>'),
+            evalue=msg.get('evalue', '')
+    )
 
 
 exec_err_msg = u"""\

--- a/nbclient/exceptions.py
+++ b/nbclient/exceptions.py
@@ -70,7 +70,7 @@ class CellExecutionError(Exception):
             ),
             ename=msg.get('ename', '<Error>'),
             evalue=msg.get('evalue', '')
-    )
+        )
 
 
 exec_err_msg = u"""\

--- a/nbclient/tests/test_client.py
+++ b/nbclient/tests/test_client.py
@@ -505,12 +505,13 @@ while True: continue
             output_nb = executor.execute()
         km = executor.start_kernel_manager()
 
-        with patch.object(km, "is_alive") as alive_mock:
-            alive_mock.return_value = False
-            # Will be a RuntimeError or subclass DeadKernelError depending
-            # on if jupyter_client or nbconvert catches the dead client first
-            with pytest.raises(RuntimeError):
-                input_nb, output_nb = executor.execute()
+        async def is_alive():
+            return False
+        km.is_alive = is_alive
+        # Will be a RuntimeError or subclass DeadKernelError depending
+        # on if jupyter_client or nbconvert catches the dead client first
+        with pytest.raises(RuntimeError):
+            input_nb, output_nb = executor.execute()
 
     def test_allow_errors(self):
         """


### PR DESCRIPTION
I don't know why mocking is_alive work for python3.8 only, I just replaced it with a plain monkeypatch. It seems to work for python3.8 and python3.7. Let's see for the other versions.